### PR TITLE
Improvements and Bugfixes

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -448,7 +448,7 @@ class FuncDeclVisitor(c_ast.NodeVisitor):
     args, retData, *others = data 
     retType, *_ = retData
     argStr = ",".join([v[2] for k,v in args.items()])
-    ret = "ptr<( ({}) -> {} )>".format(argStr, retType)
+    ret = "( ({}) -> {} )".format(argStr, retType)
     return ret
 
   def capture_typedef(self, node): 

--- a/convert.py
+++ b/convert.py
@@ -385,21 +385,12 @@ class FuncDeclVisitor(c_ast.NodeVisitor):
   }
 
   FIXED_PTR_MAPPING = { 
-    "double" : "double",
-    "float" : "float",
-    "int" : "int",
-    "long" : "long",
     "char" : "byte",
-    "byte" : "byte",
     "void" : "?",
     # This only affects pointers to structures
     #   if it is a struct by value - then we 
     #   have to handle it a different way. 
     "struct" : "?",
-    "ptr<?>" : "ptr<?>",
-    "ptr<byte>" : "ptr<byte>",
-    # This is a special case
-    "funcdef" : "funcdef"    
   }
 
   def __init__(self, opts): 
@@ -424,7 +415,7 @@ class FuncDeclVisitor(c_ast.NodeVisitor):
     self.parent = oldparent
 
   def convert_ptr_type(self, lbType, numPtrs):
-    ptrType = self.FIXED_PTR_MAPPING[lbType]
+    ptrType = self.FIXED_PTR_MAPPING.get(lbType, lbType)
     prefix = "ptr<" * numPtrs
     suffix = ">" * numPtrs
     return prefix + ptrType + suffix

--- a/convert.py
+++ b/convert.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from pycparser import c_parser, c_ast, parse_file
 import pycparser_fake_libc
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 class Exporter(object):
 

--- a/convert.py
+++ b/convert.py
@@ -257,7 +257,7 @@ class EnumExporter(LBStanzaExporter):
     self._enumerators = enumerators
 
   def dump_enum_deftypes(self):
-    self.lprint("public deftype {}".format(self._name))
+    self.lprint("public deftype {} <: Equalable".format(self._name))
     for eName, v in self._enumerators :
       self.lprint("public deftype {} <: {}".format(eName, self._name))
     self.lprint("")
@@ -295,6 +295,10 @@ class EnumExporter(LBStanzaExporter):
           self.lprint("(x:{}) : print(o, \"{}\")".format(eName, eName))
     self.lprint("")
 
+  def dump_equals(self):
+    self.lprint("public defmethod equal? (a:{}, b:{}) -> True|False :".format(self._name, self._name))
+    with self.indented():
+      self.lprint("to-int(a) == to-int(b)")
 
   def dump_enums(self, opts): 
     self.dump_autogen_header()

--- a/convert.py
+++ b/convert.py
@@ -287,7 +287,7 @@ class EnumExporter(LBStanzaExporter):
     self.lprint("")
 
   def dump_print(self):
-    self.lprint("defmethod print (o:OutputStream, v:{}) :".format(self._name))
+    self.lprint("public defmethod print (o:OutputStream, v:{}) :".format(self._name))
     with self.indented():
       self.lprint("match(v) :")
       with self.indented():

--- a/convert.py
+++ b/convert.py
@@ -506,6 +506,8 @@ class FuncDeclVisitor(c_ast.NodeVisitor):
           #  to use a type definition.
           self._enums[param.type.declname] = [] # @TODO implement Enum List Capture
           logging.debug("{}: Captured Enum: {}".format(node.coord, param.type.declname))
+        elif type(baseNode) is c_ast.Union:
+          logging.warn("Ignoring Typedef of Base Union: {}".format(baseNode))
         else:
           raise RuntimeError("{}: Unhandled declaration base: {}".format(node.coord, baseNode))
         return

--- a/convert.py
+++ b/convert.py
@@ -256,10 +256,17 @@ class EnumExporter(LBStanzaExporter):
     self._name = name
     self._enumerators = enumerators
 
+  def to_type(self, eName):
+    return "{}_t".format(eName)
+
   def dump_enum_deftypes(self):
     self.lprint("public deftype {} <: Equalable".format(self._name))
     for eName, v in self._enumerators :
-      self.lprint("public deftype {} <: {}".format(eName, self._name))
+      self.lprint("public deftype {} <: {}".format(self.to_type(eName), self._name))
+    self.lprint("")
+
+    for eName, v in self._enumerators :
+      self.lprint("public val {} = new {}".format(eName, self.to_type(eName)))
     self.lprint("")
 
   def dump_to_int(self):
@@ -268,7 +275,7 @@ class EnumExporter(LBStanzaExporter):
       self.lprint("match(v) :")
       with self.indented():
         for eName, v in self._enumerators:
-          self.lprint("(x:{}) : {}".format(eName,v))
+          self.lprint("(x:{}) : {}".format(self.to_type(eName),v))
     self.lprint("")
 
   def dump_constructor(self):
@@ -277,7 +284,7 @@ class EnumExporter(LBStanzaExporter):
       self.lprint("switch {v == _}:")
       with self.indented():
         for eName, v in self._enumerators :
-          self.lprint("{} : new {}".format(v, eName))
+          self.lprint("{} : {}".format(v, eName))
         self.lprint("else: throw(Exception(\"{}: Invalid Enum Value: %_\" % [v]))".format(self._name))
     self.lprint("")
 
@@ -292,13 +299,14 @@ class EnumExporter(LBStanzaExporter):
       self.lprint("match(v) :")
       with self.indented():
         for eName, v in self._enumerators :
-          self.lprint("(x:{}) : print(o, \"{}\")".format(eName, eName))
+          self.lprint("(x:{}) : print(o, \"{}\")".format(self.to_type(eName), eName))
     self.lprint("")
 
   def dump_equals(self):
     self.lprint("public defmethod equal? (a:{}, b:{}) -> True|False :".format(self._name, self._name))
     with self.indented():
       self.lprint("to-int(a) == to-int(b)")
+    self.lprint("")
 
   def dump_enums(self, opts): 
     self.dump_autogen_header()
@@ -309,6 +317,7 @@ class EnumExporter(LBStanzaExporter):
     self.dump_to_int()
     self.dump_constructor()
     self.dump_print()
+    self.dump_equals()
 
 
 class FuncDeclVisitor(c_ast.NodeVisitor): 


### PR DESCRIPTION
This PR fixes some bugs with the way that function pointers were being expressed.
Additionally, this updates the non-standard enum generator (for enums that can't use `defenum`) to be more inline with the default `defenum` approach so that they can be used interchangeably. 