### PR TITLE
Update for Stanza 0.18.10+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycparser==2.21
 pycparser-fake-libc==2.21
+wheel==0.41.2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 def read(fname):
 	try:


### PR DESCRIPTION
This PR updates the wrapper generator to use the simplified implementation present in stanza version 0.18.10 and onward.

The stanza compiler will now handle dynamic and static library invocations via just the one syntax. 